### PR TITLE
Update for deeplink handling

### DIFF
--- a/ema_senseye/LoadingView.swift
+++ b/ema_senseye/LoadingView.swift
@@ -1,0 +1,10 @@
+import Foundation
+import SwiftUI
+
+struct LoadingView: View {
+    
+    var body: some View {
+        Text("Loading test session...")
+    }
+    
+}

--- a/ema_senseye/ema_senseyeApp.swift
+++ b/ema_senseye/ema_senseyeApp.swift
@@ -9,40 +9,26 @@ import SwiftUI
 import senseye_ios_sdk
 @main
 struct ema_senseyeApp: App {
-    @Environment(\.scenePhase) var scenePhase
-    //var senseyeSDK: SenseyeSDK = SenseyeSDK(userId: "john2", taskIds: [.firstCalibration], databaseLocation: "ema_wellness")
-    //var senseyeSDK = SenseyeSDK()
-    @State var launchURL:URL = URL(fileURLWithPath: "https://www.example.com")
-    @State var URLLoaded:Bool = false
-    let initialBrightness = UIScreen.main.brightness
+
+    @State var activeTab = 0
+    @State var currentPatientId = "blank"
     
     var body: some Scene {
         WindowGroup {
-            //.onOpenURL(perform: {url in print(url.absoluteString)})}.onChange(of: scenePhase) { newScene in
-            //EntryView(cameFromUrl: $launchURL).onOpenURL(perform: {url in launchURL = url})}.onChange(of: scenePhase)
-            EntryView(cameFromUrl: $launchURL, urlLoaded: $URLLoaded).onOpenURL(perform: handleURL).onChange(of: scenePhase)
-            { newScene in
-                if newScene == .active {
-                    DispatchQueue.main.async {
-                        UIScreen.main.brightness = 1.0
-                        UIApplication.shared.isIdleTimerDisabled = true
-                    }
-                } else {
-                    DispatchQueue.main.async {
-                        UIScreen.main.brightness = initialBrightness
-                        UIApplication.shared.isIdleTimerDisabled = false
-                    }
-                }
+            TabView(selection: $activeTab, content: {
+                LoadingView().tag(0)
+                
+                let initializedSdkObject = SenseyeSDK(userId: self.currentPatientId, taskIds: [.firstCalibration], shouldCollectSurveyInfo: false, requiresAuth: false, databaseLocation: "ema_wellness", shouldUseFirebaseLogging: false)
+                EntryView(senseyeSDK: initializedSdkObject).tag(1)
+            }).onOpenURL { url in
+                let patientId = URLComponents(url: url, resolvingAgainstBaseURL: true)?.host ?? "blank"
+                currentPatientId = patientId
+                activeTab = 1
             }
-        }}
-    
-    func handleURL(_ url: URL)
-    {
-        launchURL = url
-        URLLoaded = true
-        //print(url)
-        
-        //var senseyeSDK = SenseyeSDK(userId: url.lastPathComponent, taskIds: [.firstCalibration], databaseLocation: "ema_wellness")
-        //await senseyeSDK.senseyeTabView()
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .ignoresSafeArea()
+            .edgesIgnoringSafeArea(.all)
+        }
     }
+    
 }

--- a/ema_senseye/ema_senseyeApp.swift
+++ b/ema_senseye/ema_senseyeApp.swift
@@ -19,7 +19,9 @@ struct ema_senseyeApp: App {
                 LoadingView().tag(0)
                 
                 let initializedSdkObject = SenseyeSDK(userId: self.currentPatientId, taskIds: [.firstCalibration], shouldCollectSurveyInfo: false, requiresAuth: false, databaseLocation: "ema_wellness", shouldUseFirebaseLogging: false)
-                EntryView(senseyeSDK: initializedSdkObject).tag(1)
+                EntryView(senseyeSDK: initializedSdkObject).tag(1).onAppear {
+                    UIApplication.shared.isIdleTimerDisabled = true
+                }
             }).onOpenURL { url in
                 let patientId = URLComponents(url: url, resolvingAgainstBaseURL: true)?.host ?? "blank"
                 currentPatientId = patientId


### PR DESCRIPTION
This PR updates the root App view to contain a TabView that contains two views - a Launch/Loading view and a EntryView that contains the Calibration task. 

On launch of the app (without a deeplink) the app will display the Launch/Loading view. 

On launch of the app from a deeplink, `onOpenUrl` will be triggered, updated the `activeTab` to `1` opening the `EntryView` with the CalibrationTask. 

The patient ID is now parsed using `URLComponents` 

Note:
I wasn't able to test this in Xcode, so these changes were made manually in a TextEditor. Please test it out in your Xcode first before merging to make sure I didn't miss any obvious brackets or build errors